### PR TITLE
2.4GHz network clarification and added newline

### DIFF
--- a/examples/WiFi_TinyShield_Cayenne-BMA250/WiFi_TinyShield_Cayenne-BMA250.ino
+++ b/examples/WiFi_TinyShield_Cayenne-BMA250/WiFi_TinyShield_Cayenne-BMA250.ino
@@ -21,7 +21,7 @@
 
 /*********************** EDIT THIS SECTION TO MATCH YOUR INFO *************************/
 // WiFi network information
-char ssid[] = "TinyCircuits";        //  your network SSID (name)
+char ssid[] = "TinyCircuits";        //  your 2.4GHz network SSID (name)
 char wifiPassword[] = "__________";  // your network password
 
 // Cayenne authentication info. This should be obtained from the Cayenne Dashboard.

--- a/examples/WiFi_TinyShield_example/WiFi_TinyShield_example.ino
+++ b/examples/WiFi_TinyShield_example/WiFi_TinyShield_example.ino
@@ -55,6 +55,6 @@ void setup() {
 
 void loop()
 {
-  SerialMonitorInterface.print("Main loop entered. Now that we're connected, let's do something cool.");
+  SerialMonitorInterface.println("Main loop entered. Now that we're connected, let's do something cool.");
   delay(60000); // Wait a minute before going back through main loop
 }

--- a/examples/WiFi_TinyShield_example/WiFi_TinyShield_example.ino
+++ b/examples/WiFi_TinyShield_example/WiFi_TinyShield_example.ino
@@ -18,7 +18,7 @@
 #include <WiFi101.h>
 
 /*********************** EDIT THIS SECTION TO MATCH YOUR INFO *************************/
-char ssid[] = "TinyCircuits";  //  your network SSID (name)
+char ssid[] = "TinyCircuits";  //  your 2.4GHz network SSID (name)
 char wifiPassword[] = "********";  // your network password
 
 // Define Serial object based on which TinyCircuits processor board is used.


### PR DESCRIPTION
I spent a bunch of time wondering why my TinyShield WiFi would not connect.
Turns out that I didn't have 2.4GHz turned on for my access point.